### PR TITLE
(Refactor) Duplicated controllers. Naming.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage
 
 # Compiled Dirs (http://nodejs.org/api/addons.html)
 build/
-dist/
+# dist/
 client/lib
 .DS_Store
 client/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ coverage
 
 # Compiled Dirs (http://nodejs.org/api/addons.html)
 build/
-# dist/
+dist/
 client/lib
 .DS_Store
 client/.DS_Store

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: node index.js
+web: node server/server.js

--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: node index.js

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -2,8 +2,8 @@ var app = angular.module('uSpeak', [
   'ngMaterial',
   'ionic',
   'ui.router',
-  'uSpeak.language1',
-  'uSpeak.language2',
+  'uSpeak.languageSource',
+  'uSpeak.languageTarget',
   'uSpeak.loading',
   'uSpeak.chat'
   ])
@@ -13,15 +13,15 @@ var app = angular.module('uSpeak', [
 
 .config(function($stateProvider, $urlRouterProvider){
   $stateProvider
-    .state('language1', {
+    .state('languageSource', {
       url: '/',
-      templateUrl: 'app/language1/language1Template.html',
-      controller: 'language1Controller'
+      templateUrl: 'app/languageSource/languageSourceTemplate.html',
+      controller: 'languageSourceController'
     })
-    .state('language2', {
+    .state('languageTarget', {
       url: '/1',
-      templateUrl: 'app/language2/language2Template.html',
-      controller: 'language2Controller'
+      templateUrl: 'app/languageTarget/languageTargetTemplate.html',
+      controller: 'languageTargetController'
     })
     .state('loading', {
       url: '/loading',

--- a/client/app/app.js
+++ b/client/app/app.js
@@ -19,7 +19,7 @@ var app = angular.module('uSpeak', [
       controller: 'languageSourceController'
     })
     .state('languageTarget', {
-      url: '/1',
+      url: '/target',
       templateUrl: 'app/languageTarget/languageTargetTemplate.html',
       controller: 'languageTargetController'
     })

--- a/client/app/languageSource/languageSourceController.js
+++ b/client/app/languageSource/languageSourceController.js
@@ -1,11 +1,11 @@
-angular.module('uSpeak.language1', [])
+angular.module('uSpeak.languageSource', [])
 
-.controller('language1Controller', function($scope, languageService, $state){
+.controller('languageSourceController', function($scope, languageService, $state){
   $scope.languages = [['English','us'],['Chinese','cn'],['Spanish','es'],['French','fr'],['Italian','it']];
   $scope.test = function(lang){
   	console.log('working');
     languageService.language.source = lang[0];
-    $state.go('language2');
+    $state.go('languageTarget');
   };
 
 });

--- a/client/app/languageSource/languageSourceTemplate.html
+++ b/client/app/languageSource/languageSourceTemplate.html
@@ -1,13 +1,13 @@
 <ion-view view-title="Home">
-  <ion-content ng-controller="language2Controller">
+  <ion-content ng-controller="languageSourceController">
     <md-input-container flex columns="1">
       <label>Language</label>
-      <input placeholder="Select learning language" ng-model="searchText">
+      <input placeholder="Select your native language" ng-model="searchText">
     </md-input-container>
 
 
   <md-content>
-      <md-card ng-repeat="language in languages | filter:searchText" ng-click="test(language)">
+      <md-card ng-repeat="language in languages | filter:searchText">
         <md-button class="md-raised" ng-click="test(language)">
           <span class="flag-icon flag-icon-{{ language[1] }}"></span>
           <span class="lang">{{language[0]}}</span>

--- a/client/app/languageSource/languageSourceTemplate.html
+++ b/client/app/languageSource/languageSourceTemplate.html
@@ -1,5 +1,5 @@
 <ion-view view-title="Home">
-  <ion-content ng-controller="languageSourceController">
+  <ion-content>
     <md-input-container flex columns="1">
       <label>Language</label>
       <input placeholder="Select your native language" ng-model="searchText">

--- a/client/app/languageTarget/LanguageTargetController.js
+++ b/client/app/languageTarget/LanguageTargetController.js
@@ -1,6 +1,6 @@
-angular.module('uSpeak.language2', [])
+angular.module('uSpeak.languageTarget', [])
 
-.controller('language2Controller', function($scope, languageService, $state){
+.controller('languageTargetController', function($scope, languageService, $state){
   $scope.languages = [['English','us'],['Chinese','cn'],['Spanish','es'],['French','fr'],['Italian','it']];
   $scope.test = function(lang){
     languageService.language.target = lang[0];

--- a/client/app/languageTarget/LanguageTargetController.js
+++ b/client/app/languageTarget/LanguageTargetController.js
@@ -2,8 +2,8 @@ angular.module('uSpeak.languageTarget', [])
 
 .controller('languageTargetController', function($scope, languageService, $state){
   $scope.languages = [['English','us'],['Chinese','cn'],['Spanish','es'],['French','fr'],['Italian','it']];
-  $scope.test = function(lang){
-    languageService.language.target = lang[0];
+  $scope.test = function(lang) {
+    languageService.language.target = lang[0];    
     $state.go('loading');
   };
 

--- a/client/app/languageTarget/LanguageTargetTemplate.html
+++ b/client/app/languageTarget/LanguageTargetTemplate.html
@@ -1,5 +1,5 @@
 <ion-view view-title="Home">
-  <ion-content ng-controller="languageTargetController">
+  <ion-content>
     <md-input-container flex columns="1">
       <label>Language</label>
       <input placeholder="Select learning language" ng-model="searchText">

--- a/client/app/languageTarget/LanguageTargetTemplate.html
+++ b/client/app/languageTarget/LanguageTargetTemplate.html
@@ -1,13 +1,13 @@
 <ion-view view-title="Home">
-  <ion-content ng-controller="language1Controller">
+  <ion-content ng-controller="languageTargetController">
     <md-input-container flex columns="1">
       <label>Language</label>
-      <input placeholder="Select your native language" ng-model="searchText">
+      <input placeholder="Select learning language" ng-model="searchText">
     </md-input-container>
 
 
   <md-content>
-      <md-card ng-repeat="language in languages | filter:searchText">
+      <md-card ng-repeat="language in languages | filter:searchText" ng-click="test(language)">
         <md-button class="md-raised" ng-click="test(language)">
           <span class="flag-icon flag-icon-{{ language[1] }}"></span>
           <span class="lang">{{language[0]}}</span>

--- a/client/app/loading/loadingController.js
+++ b/client/app/loading/loadingController.js
@@ -1,4 +1,4 @@
-angular.module('uSpeak.loading', ['ionic'])
+angular.module('uSpeak.loading', [])
 
 .controller('loadingController', function($scope, $interval, $state, languageService, Translate, Room, Phrases) {
 
@@ -8,7 +8,7 @@ angular.module('uSpeak.loading', ['ionic'])
   console.log($scope.sourceLang, $scope.targetLang);
 
   if (!$scope.targetLang && !$scope.sourceLang) {
-    $state.go('language1');
+    $state.go('languageSource');
   }
 
   $scope.phrase = {
@@ -35,12 +35,18 @@ angular.module('uSpeak.loading', ['ionic'])
 
   $scope.translate();
   
-  Room.getRoom($scope.sourceLang, $scope.targetLang)
+  $scope.getRoom = function() {
+    Room.getRoom($scope.sourceLang, $scope.targetLang)
     .then(function(data) {
+      console.log('Called!');
       Room.setRoomId(data);
-      console.log(Room.getRoomId());      
+      console.log(Room.getRoomId());
       $state.go('chat');
     });
+  };
+
+  $scope.getRoom();
+
 })
 
 .factory('Phrases', function() {

--- a/client/app/loading/loadingController.js
+++ b/client/app/loading/loadingController.js
@@ -3,9 +3,7 @@ angular.module('uSpeak.loading', [])
 .controller('loadingController', function($scope, $interval, $state, languageService, Translate, Room, Phrases) {
 
   $scope.targetLang = languageService.language.target;
-  $scope.sourceLang = languageService.language.source;
-
-  console.log($scope.sourceLang, $scope.targetLang);
+  $scope.sourceLang = languageService.language.source;  
 
   if (!$scope.targetLang && !$scope.sourceLang) {
     $state.go('languageSource');
@@ -37,10 +35,8 @@ angular.module('uSpeak.loading', [])
   
   $scope.getRoom = function() {
     Room.getRoom($scope.sourceLang, $scope.targetLang)
-    .then(function(data) {
-      console.log('Called!');
-      Room.setRoomId(data);
-      console.log(Room.getRoomId());
+    .then(function(data) {      
+      Room.setRoomId(data);      
       $state.go('chat');
     });
   };

--- a/client/app/loading/loadingTemplate.html
+++ b/client/app/loading/loadingTemplate.html
@@ -1,5 +1,5 @@
 <ion-view title="Loading">
-  <ion-content padding="true" ng-controller="loadingController">
+  <ion-content padding="true">
     
     <div class="looking-for-match" ng-hide="isMatch">
       <md-progress-circular class="md-accent md-hue-1 circular-loading" md-mode="indeterminate"></md-progress-circular>

--- a/client/index.html
+++ b/client/index.html
@@ -37,8 +37,8 @@
 <script src="app/services/translate.js"></script>
 <script src="app/services/languageSelect.js"></script>
 <script src="app/services/room.js"></script>
-<script src="app/language1/language1Controller.js"></script>
-<script src="app/language2/language2Controller.js"></script>
+<script src="app/languageSource/languageSourceController.js"></script>
+<script src="app/languageTarget/languageTargetController.js"></script>
 <script src="app/loading/loadingController.js"></script>
 <script src="app/chat/chatController.js"></script>
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,10 @@
     "start": "node server/server.js",
     "postinstall": "bower install"
   },
+  "engines": {
+    "node": "0.10.35",
+    "npm": "2.4.x"
+  }, 
   "repository": {
     "type": "git",
     "url": "https://github.com/Aberrant-Marble/Aberrant-Marble"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "homepage": "https://github.com/Aberrant-Marble/Aberrant-Marble",
   "dependencies": {
     "body-parser": "^1.10.2",
+    "bower": "^1.3.12",
     "express": "^4.11.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "server.js",
   "description": "Language learning whenever you want!",
   "scripts": {
-    "start": "nodemon server/server.js"
+    "start": "node server/server.js",
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",

--- a/server/server.js
+++ b/server/server.js
@@ -13,6 +13,7 @@ var host = process.env.host || '127.0.0.1';
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true}));
+// app.use(express.static(__dirname + '/../client/'));
 app.use(express.static(__dirname + '/../client/'));
 
 app.listen(port);

--- a/server/server.js
+++ b/server/server.js
@@ -13,7 +13,6 @@ var host = process.env.host || '127.0.0.1';
 
 app.use(bodyParser.json());
 app.use(bodyParser.urlencoded({ extended: true}));
-// app.use(express.static(__dirname + '/../client/'));
 app.use(express.static(__dirname + '/../client/'));
 
 app.listen(port);


### PR DESCRIPTION
Major Changes:
- Changed Names of Language pages.
  - Did this after a weird bug with heroku, now there's a lot more clarity on what each state does.
- Added a few things related to deployment (Procfile, changes in package.json).
- Removed duplicate ng-controller directives... $stateProvider picks the controller for us.
